### PR TITLE
fix: added nuxt/image to modules in config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -64,7 +64,8 @@ export default {
   modules: [
     '@nuxtjs/sitemap',
     'bootstrap-vue/nuxt',
-    '@nuxtjs/axios'
+    '@nuxtjs/axios',
+    '@nuxt/image'
   ],
 
   bootstrapVue: {


### PR DESCRIPTION
After an investigation, I think we have to add @nuxt/image  in modules section in nuxt.config.js. Let's try if this fix it in Vercel.