### PR TITLE
fix: mispelled word

### DIFF
--- a/components/home/PoweredByBinance.vue
+++ b/components/home/PoweredByBinance.vue
@@ -109,7 +109,7 @@
               Decentralized Exchange Module
             </p>
             <p class="text-center text-base text-tertiary">
-              Aggregate trades against omni-chain decentralized liquidty enabled by our SifChain module.
+              Aggregate trades against omni-chain decentralized liquidity enabled by our SifChain module.
             </p>
           </b-card>
         </div>


### PR DESCRIPTION
Fixed mispelled word (liquidity)

![image](https://user-images.githubusercontent.com/1263509/148684544-3e1a0893-6e30-41b1-b084-710bd3c093dd.png)
