### PR TITLE
fix: problem with medium rss fixed

### DIFF
--- a/config/medium.js
+++ b/config/medium.js
@@ -1,7 +1,7 @@
 
 const RSS_TO_JSON_ENDPOINT = 'https://api.rss2json.com/v1/api.json'
 
-const MEDIUM_FEED_URL = 'https://unizen-io.medium.com/feed'
+const MEDIUM_FEED_URL = 'https://medium.com/feed/@unizen-io' // 'https://unizen-io.medium.com/feed'
 // MEMO: test Medium
 // const MEDIUM_FEED_URL = 'https://medium.com/feed/@KonradDaWo'
 


### PR DESCRIPTION
@martin-zencex please merge this PR. Now it works getting the posts from the user, not from the site itself. The site is behind cloudfare policies, so it is being stopped by a browser checking. With the user directly it doesn't happen. 

I have just changed the url. I have to say that it only recovers the 10 more recent posts. But I think it's not a problem because we show the most recent in unizen.io and then the user jumps to the blog and there he can find all the posts.
Maybe in the future, if we have more problems with this, we can implement the official api to get the posts. But it's not needed for now.